### PR TITLE
ソースコード文字化け対応

### DIFF
--- a/Classes/GameScene.cpp
+++ b/Classes/GameScene.cpp
@@ -1,8 +1,5 @@
 #include "GameScene.h"
 
-//文字化けしないようのおまじない
-#pragma execution_character_set("utf-8")
-
 using namespace cocos2d;
 using namespace std;
 

--- a/proj.win32/TetrisTeamB.vcxproj
+++ b/proj.win32/TetrisTeamB.vcxproj
@@ -112,6 +112,9 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)\Resources\" /D /E /I /F /Y
       <Outputs>$(TargetName).cab</Outputs>
       <Inputs>$(TargetFileName)</Inputs>
     </CustomBuildStep>
+    <ClCompile>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"/utf-8" %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>


### PR DESCRIPTION
プロジェクト設定でコマンドラインに"/utf-8"を追加しました、この対応で常にUTF-8のソースコードになります。<br>
Pragmaが不要になったので削除